### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/becas_sntsa/views.py
+++ b/becas_sntsa/views.py
@@ -237,7 +237,11 @@ def download_file(request, file_path):
     if not request.user.is_staff:
         return HttpResponseForbidden("You do not have permission to access this file.")
 
-    file_full_path = os.path.join(settings.MEDIA_ROOT, file_path)
+    normalized_path = os.path.normpath(file_path)
+    file_full_path = os.path.join(settings.MEDIA_ROOT, normalized_path)
+    if not file_full_path.startswith(settings.MEDIA_ROOT):
+        return HttpResponseForbidden("Invalid file path.")
+
     if os.path.exists(file_full_path):
         return FileResponse(open(file_full_path, 'rb'))
     else:


### PR DESCRIPTION
Potential fix for [https://github.com/ksobrenat32/scholarships-db/security/code-scanning/3](https://github.com/ksobrenat32/scholarships-db/security/code-scanning/3)

To fix the issue, the `file_path` parameter must be validated and normalized before constructing the full file path. The best approach is to use `os.path.normpath` to normalize the path and ensure it remains within the `settings.MEDIA_ROOT` directory. This involves checking that the normalized path starts with `settings.MEDIA_ROOT`. If the path is invalid or attempts to escape the root directory, the function should return an error.

**Steps to implement the fix:**
1. Normalize the `file_path` using `os.path.normpath`.
2. Construct the full path using `os.path.join`.
3. Verify that the normalized path starts with `settings.MEDIA_ROOT`.
4. If the path is invalid, return an error response.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
