### PR TITLE
Fix email sending and missing schemas

### DIFF
--- a/becas/settings.py
+++ b/becas/settings.py
@@ -176,12 +176,12 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # Email settings
 _default_email_backend = (
     'django.core.mail.backends.console.EmailBackend'
-    if DEBUG
+    if DEBUG and not os.environ.get('EMAIL_HOST')
     else 'django.core.mail.backends.smtp.EmailBackend'
 )
 EMAIL_BACKEND = os.environ.get('EMAIL_BACKEND', _default_email_backend)
 EMAIL_HOST = os.environ.get('EMAIL_HOST', '')
-EMAIL_PORT = int(os.environ.get('EMAIL_PORT') or 0)
+EMAIL_PORT = int(os.environ.get('EMAIL_PORT') or 25)
 EMAIL_USE_TLS = str_to_bool(os.environ.get('EMAIL_USE_TLS', 'True'))
 EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER', '')
 EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', '')

--- a/becas_sntsa/templates/confirmar_nuevo_correo.html
+++ b/becas_sntsa/templates/confirmar_nuevo_correo.html
@@ -3,7 +3,7 @@ Hola {{ user.trabajador.nombre }} {{ user.trabajador.apellido_paterno }}{% if us
 Has solicitado cambiar el correo electrónico asociado a tu cuenta de Becas SNTSA.
 Por favor, confirma tu nueva dirección de correo electrónico haciendo clic en el siguiente enlace:
 
-{{ request.scheme }}://{{ domain }}{% url 'confirm_email_change' uidb64=uid token=token %}
+{{ protocol }}://{{ domain }}{% url 'confirm_email_change' uidb64=uid token=token %}
 
 Si no solicitaste este cambio, simplemente ignora este mensaje.
 

--- a/becas_sntsa/views.py
+++ b/becas_sntsa/views.py
@@ -232,6 +232,7 @@ def create_trabajador(request):
                 message = render_to_string('verificar_correo.html', {
                     'user': user,
                     'domain': current_site.domain,
+                    'protocol': request.scheme,
                     'uid': urlsafe_base64_encode(force_bytes(user.pk)),
                     'token': default_token_generator.make_token(user),
                 })
@@ -597,6 +598,7 @@ def editar_usuario(request):
                 message = render_to_string('confirmar_nuevo_correo.html', {
                     'user': user,
                     'domain': current_site.domain,
+                    'protocol': request.scheme,
                     'uid': urlsafe_base64_encode(force_bytes(user.pk)),
                     'token': default_token_generator.make_token(user),
                 })


### PR DESCRIPTION
Fix email backend selection and missing schema in email links

- Update `becas/settings.py` to use `smtp.EmailBackend` if `EMAIL_HOST` is set,
  bypassing `console.EmailBackend` fallback even when `DEBUG` is True.
- Set default `EMAIL_PORT` to 25 instead of 0.
- Provide `request.scheme` as `protocol` context variable in `views.py` when using `render_to_string` for email templates.
- Update `confirmar_nuevo_correo.html` to properly use the `protocol` context variable instead of `request.scheme`.

---
*PR created automatically by Jules for task [17409926224891804307](https://jules.google.com/task/17409926224891804307) started by @ksobrenat32*